### PR TITLE
get rtc6715 rssi per 100/120ms

### DIFF
--- a/src/core/osd.c
+++ b/src/core/osd.c
@@ -314,7 +314,7 @@ void osd_analog_rssi_show(bool bShow) {
     if (g_setting.analog_rssi.calib_min == g_setting.analog_rssi.calib_max)
         rssi_volt_mv = 0;
     else {
-        rssi_volt_mv = RTC6715_GetRssi();
+        rssi_volt_mv = rtc6715_rssi;
         if (rssi_volt_mv <= g_setting.analog_rssi.calib_min)
             rssi_volt_mv = 0;
         else if (rssi_volt_mv >= g_setting.analog_rssi.calib_max)
@@ -626,9 +626,6 @@ void osd_elements_set_dummy_sources() {
 #define FC_OSD_CHECK_PERIOD 200 // 25ms
 void osd_hdzero_update(void) {
     char buf[128], i;
-
-    if (GOGGLE_VER_2)
-        RTC6715_GetRssi();
 
     if (g_osd_update_cnt < FC_OSD_CHECK_PERIOD)
         g_osd_update_cnt++;

--- a/src/core/thread.c
+++ b/src/core/thread.c
@@ -24,6 +24,7 @@
 #include "driver/it66021.h"
 #include "driver/nct75.h"
 #include "driver/oled.h"
+#include "driver/rtc6715.h"
 #include "ui/page_fans.h"
 #include "ui/page_storage.h"
 #include "ui/page_version.h"
@@ -194,6 +195,7 @@ static void threads_instance(threads_obj_t *obj) {
     obj->instance[0] = thread_peripheral;
     obj->instance[1] = thread_version;
     obj->instance[2] = thread_osd;
+    obj->instance[3] = thread_rtc6715_rssi;
 }
 
 int create_threads() {

--- a/src/core/thread.h
+++ b/src/core/thread.h
@@ -8,7 +8,7 @@ extern "C" {
 #include <stdint.h>
 
 #define THREAD_COUNT_MAX (10)
-#define THREAD_COUNT     (3)
+#define THREAD_COUNT     (4)
 
 typedef void *(*fun_thread_instance_t)(void *params);
 

--- a/src/driver/rtc6715.c
+++ b/src/driver/rtc6715.c
@@ -13,6 +13,12 @@
 #include "gpadc.h"
 #include "i2c.h"
 
+#include "../core/settings.h"
+#include "app_state.h"
+#include "ui/page_common.h"
+
+int rtc6715_rssi = 0;
+
 static uint8_t RTC6715_rssi;
 
 void MM_Write(uint8_t addr, uint32_t dat) {
@@ -79,4 +85,16 @@ int RTC6715_GetRssi() {
     rssi_adc = 3300 * value / 4096;
     // LOGI("rssi voltage: %02f", (float)rssi_adc / 1000);
     return rssi_adc;
+}
+
+extern int GOGGLE_VER_2;
+void *thread_rtc6715_rssi(void *ptr) {
+    for (;;) {
+        if (GOGGLE_VER_2) {
+            if (g_app_state == APP_STATE_VIDEO && g_source_info.source == SOURCE_ANALOG && g_setting.source.analog_module == SETTING_SOURCES_ANALOG_MODULE_INTERNAL) {
+                rtc6715_rssi = RTC6715_GetRssi();
+            }
+        }
+        usleep(100 * 1000);
+    }
 }

--- a/src/driver/rtc6715.h
+++ b/src/driver/rtc6715.h
@@ -7,6 +7,9 @@ extern "C" {
 void RTC6715_Open(int power_on, int audio_on);
 void RTC6715_SetCH(int ch);
 int RTC6715_GetRssi();
+void *thread_rtc6715_rssi(void *ptr);
+
+extern int rtc6715_rssi;
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Frequent calls to `system()` may cause Linux to crash.