### PR TITLE
Ability to switch between current source and external analog module on a fly

### DIFF
--- a/src/core/app_state.h
+++ b/src/core/app_state.h
@@ -37,7 +37,7 @@ void app_state_push(app_state_t state);
 
 void app_switch_to_menu();
 void app_exit_menu();
-void app_switch_to_analog();
+void app_switch_to_analog(bool force_external);
 void app_switch_to_av_in();
 void app_switch_to_hdmi_in();
 void app_switch_to_hdzero(bool is_default);

--- a/src/core/elrs.c
+++ b/src/core/elrs.c
@@ -275,7 +275,7 @@ void msp_process_packet() {
                         beep();
                         pthread_mutex_lock(&lvgl_mutex);
                         dvr_cmd(DVR_STOP);
-                        app_switch_to_analog();
+                        app_switch_to_analog(false);
                         app_state_push(APP_STATE_VIDEO);
                         pthread_mutex_unlock(&lvgl_mutex);
                     }
@@ -327,7 +327,7 @@ void msp_process_packet() {
                             g_setting.scan.channel = chan;
                             beep();
                             pthread_mutex_lock(&lvgl_mutex);
-                            app_switch_to_analog();
+                            app_switch_to_analog(false);
                             app_state_push(APP_STATE_VIDEO);
                             pthread_mutex_unlock(&lvgl_mutex);
                             break;

--- a/src/core/main.c
+++ b/src/core/main.c
@@ -102,7 +102,7 @@ void start_running(void) {
         app_state_push(APP_STATE_VIDEO);
         if (source == SETTING_AUTOSCAN_SOURCE_ANALOG) { // analog
             g_hw_stat.av_pal[1] = g_setting.source.analog_format;
-            app_switch_to_analog();
+            app_switch_to_analog(false);
             g_source_info.source = SOURCE_ANALOG;
         } else if (source == SETTING_AUTOSCAN_SOURCE_AV_IN) { // AV in
             g_hw_stat.av_pal[0] = g_setting.source.analog_format;

--- a/src/ui/page_imagesettings.c
+++ b/src/ui/page_imagesettings.c
@@ -131,7 +131,7 @@ static void page_imagesettings_enter() {
         break;
 
     case SOURCE_ANALOG:
-        app_switch_to_analog();
+        app_switch_to_analog(false);
         g_bShowIMS = true;
         break;
     }

--- a/src/ui/page_input.c
+++ b/src/ui/page_input.c
@@ -51,7 +51,7 @@ static void nop() {}
 static void rollerNop(uint8_t key) { (void)key; }
 
 static const action_t btnActions[] = {
-    {.id = 11, .name = "None", .functionPtr = &nop},
+    {.id = 10, .name = "None", .functionPtr = &nop},
     {.id = 0, .name = "Toggle OSD", .functionPtr = &osd_toggle},
     {.id = 1, .name = "Main menu", .functionPtr = &app_switch_to_menu},
     {.id = 2, .name = "Toggle DVR", .functionPtr = &dvr_toggle},
@@ -62,7 +62,7 @@ static const action_t btnActions[] = {
     {.id = 7, .name = "Star DVR", .functionPtr = &dvr_star},
     {.id = 8, .name = "Toggle source", .functionPtr = &source_toggle},
     {.id = 9, .name = "Cycle source", .functionPtr = &source_cycle},
-    {.id = 10, .name = "Toggle cam", .functionPtr = &source_toggle_cam},
+    {.id = 11, .name = "Toggle cam", .functionPtr = &source_toggle_cam},
 };
 
 static const action_t rollerActions[] = {

--- a/src/ui/page_input.c
+++ b/src/ui/page_input.c
@@ -51,7 +51,7 @@ static void nop() {}
 static void rollerNop(uint8_t key) { (void)key; }
 
 static const action_t btnActions[] = {
-    {.id = 10, .name = "None", .functionPtr = &nop},
+    {.id = 11, .name = "None", .functionPtr = &nop},
     {.id = 0, .name = "Toggle OSD", .functionPtr = &osd_toggle},
     {.id = 1, .name = "Main menu", .functionPtr = &app_switch_to_menu},
     {.id = 2, .name = "Toggle DVR", .functionPtr = &dvr_toggle},
@@ -62,6 +62,7 @@ static const action_t btnActions[] = {
     {.id = 7, .name = "Star DVR", .functionPtr = &dvr_star},
     {.id = 8, .name = "Toggle source", .functionPtr = &source_toggle},
     {.id = 9, .name = "Cycle source", .functionPtr = &source_cycle},
+    {.id = 10, .name = "Toggle cam", .functionPtr = &source_toggle_cam},
 };
 
 static const action_t rollerActions[] = {

--- a/src/ui/page_osd.c
+++ b/src/ui/page_osd.c
@@ -122,7 +122,7 @@ static void open_element_pos_preview() {
         break;
 
     case SOURCE_ANALOG:
-        app_switch_to_analog();
+        app_switch_to_analog(false);
         break;
     }
 

--- a/src/ui/page_source.h
+++ b/src/ui/page_source.h
@@ -13,6 +13,7 @@ extern page_pack_t pp_source;
 void source_status_timer();
 void source_toggle();
 void source_cycle();
+void source_toggle_cam();
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
I'm currently working on a simple external module (PCB adapter and camera) that can be used for video pass-through. 

This pull request adds the ability to create a button that toggles the image between the current source and the external module.