### PR TITLE
Ported .devcontainer files from hdz-goggles repo

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,5 @@
+FROM --platform=linux/x86_64 mcr.microsoft.com/devcontainers/base:ubuntu
+
+RUN export DEBIAN_FRONTEND=noninteractive && \
+    apt-get update && \
+    apt-get -y install --no-install-recommends cmake build-essential ninja-build libsdl2-dev

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,28 @@
+{
+    "name": "arm-linux-musleabihf",
+    "build": {
+        "dockerfile": "Dockerfile"
+    },
+    "runArgs": [
+        "--cap-add=SYS_PTRACE",
+        "--security-opt",
+        "seccomp=unconfined"
+    ],
+    "customizations": {
+        "vscode": {
+            // Set *default* container specific settings.json values on container create.
+            "settings": {
+                "cmake.configureArgs": [
+                    "-DCMAKE_TOOLCHAIN_FILE=${workspaceFolder}/toolchain/share/buildroot/toolchainfile.cmake"
+                ]
+            },
+            // Add the IDs of extensions you want installed when the container is created.
+            "extensions": [
+                "ms-vscode.cpptools",
+                "ms-vscode.cmake-tools"
+            ]
+        }
+    },
+    "postCreateCommand": "bash setup.sh",
+    "remoteUser": "vscode"
+}


### PR DESCRIPTION
Just copied over the devcontainer files from the base repo so that users that only pull the g2 repository will have the prompt to start building the devcontainer show up in vscode, makes development slightly easier! 